### PR TITLE
Update `cachix/install-nix-action`.

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v22
       - uses: cachix/cachix-action@v12
         with:
           name: crunchy-public

--- a/crystal/build-crystal-package.nix
+++ b/crystal/build-crystal-package.nix
@@ -48,7 +48,7 @@ let
     })
     (import shardsFile));
 
-  defaultOptions = [ "--release" "--progress" "--verbose" ];
+  defaultOptions = [ "--release" "--progress" "--verbose" "--no-debug" ];
 
   buildDirectly = shardsFile == null || crystalBinaries != { };
 
@@ -137,7 +137,6 @@ stdenv.mkDerivation (mkDerivationArgs // {
     fi
   '') ++ [
     "remove-references-to -t ${lib.getLib crystal} $out/bin/*"
-    "chmod -x $out/bin/*.dwarf"
     "runHook postInstall"
   ]));
 


### PR DESCRIPTION
Updates this action from v20 -> v22. This is necessary for our `macos` CI to continue working.

In short, a `System Integrity Protection` issue is being encountered when running the action on macos-12 (currently macos-latest) runners.

```
Could not set environment: 150: Operation not permitted while System
Integrity Protection is engaged
```

This has been resolved in v22 [1]. I didn't dig down too far to determine what was documented as the root cause. However, this update is necessary to get our checks back on track.

[1] https://github.com/cachix/install-nix-action/releases/tag/v22