### PR TITLE
Downgrade clang/llvm to 15

### DIFF
--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_17;
+  llvmPackages = pkgs.llvmPackages_15;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_17
-, llvm_17
+, clang_15
+, llvm_15
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_17
+    llvm_15
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_17 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_15 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \


### PR DESCRIPTION
Crystal 1.11 might not be ready to support LLVM 17 on macOS yet.