### PR TITLE
Static build checks

### DIFF
--- a/crystal/crystal.nix
+++ b/crystal/crystal.nix
@@ -53,7 +53,7 @@ lib.fix (compiler:
     nativeBuildInputs = [ makeBinaryWrapper installShellFiles crystal_prebuilt ];
 
     buildInputs = [ boehmgc gmp libevent libffi libxml2 libyaml openssl pcre2 zlib ]
-      ++ lib.optionals isDarwin [ libiconv ];
+      ++ lib.optionals isDarwin [ libiconv llvmPackages.libcxxabi ];
 
     patches = [ (substituteAll { src = ./tzdata.patch; inherit tzdata; }) ];
 

--- a/crystal/crystal.nix
+++ b/crystal/crystal.nix
@@ -39,10 +39,10 @@ lib.fix (compiler:
     passthru = rec {
       # simple builders that set a bunch of defaults
       mkPkg = callPackage ./common-build-args.nix { inherit buildCrystalPackage; };
-      #mkStaticPkg = callPackage ./common-build-args.nix { buildCrystalPackage = buildStaticCrystalPackage; };
+      mkStaticPkg = callPackage ./common-build-args.nix { buildCrystalPackage = buildStaticCrystalPackage; };
       # base builders
       buildCrystalPackage = callPackage ./build-crystal-package.nix { crystal = compiler; };
-      #buildStaticCrystalPackage = callPackage ./build-crystal-package.nix { crystal = compiler; stdenv = pkgsStatic.stdenv; };
+      buildStaticCrystalPackage = callPackage ./build-crystal-package.nix { crystal = compiler; stdenv = pkgsStatic.stdenv; };
     };
 
     disallowedReferences = [ crystal_prebuilt ];

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_16;
+  llvmPackages = pkgs.llvmPackages_14;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_15;
+  llvmPackages = pkgs.llvmPackages_16;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_17;
+  llvmPackages = pkgs.llvmPackages_15;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_13;
+  llvmPackages = pkgs.llvmPackages_12;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_14;
+  llvmPackages = pkgs.llvmPackages_13;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_12;
+  llvmPackages = pkgs.llvmPackages_11;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/default.nix
+++ b/crystal/default.nix
@@ -20,7 +20,7 @@ let
   arch = archs.${system};
   src = pkgs.fetchurl src_urls.${arch};
 
-  llvmPackages = pkgs.llvmPackages_11;
+  llvmPackages = pkgs.llvmPackages_9;
 
   packages = rec {
     crystal_prebuilt =

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_16
-, llvm_16
+, clang_14
+, llvm_14
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_16
+    llvm_14
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_16 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_14 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_13
-, llvm_13
+, clang_12
+, llvm_12
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_13
+    llvm_12
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_13 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_12 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_15
-, llvm_15
+, clang_16
+, llvm_16
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_15
+    llvm_16
     boehmgc
     gmp
     libevent
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     tar xvf ${crystal_o}
     tar xvf ${src}
-    cc crystal.o -o crystal crystal-${version}/src/llvm/ext/llvm_ext.cc -lLLVM-17 -lstdc++ -lpcre2-8 -lm -lgc -lpthread -levent -lrt -lpthread -ldl
+    cc crystal.o -o crystal crystal-${version}/src/llvm/ext/llvm_ext.cc -lLLVM-16 -lstdc++ -lpcre2-8 -lm -lgc -lpthread -levent -lrt -lpthread -ldl
   '';
 
   enableParallelBuilding = true;
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_15 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_16 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_11
-, llvm_11
+, clang_9
+, llvm_9
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_11
+    llvm_9
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_11 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_9 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_17
-, llvm_17
+, clang_15
+, llvm_15
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_17
+    llvm_15
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_17 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_15 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_14
-, llvm_14
+, clang_13
+, llvm_13
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_14
+    llvm_13
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_14 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_13 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/crystal/from_object_file.nix
+++ b/crystal/from_object_file.nix
@@ -6,8 +6,8 @@
 , makeWrapper
 , fetchurl
   # crystal deps
-, clang_12
-, llvm_12
+, clang_11
+, llvm_11
 , boehmgc
 , gmp
 , libevent
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = [
-    llvm_12
+    llvm_11
     boehmgc
     gmp
     libevent
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     install -Dm755 crystal $bin/bin/crystal
 
     wrapProgram $bin/bin/crystal \
-   --prefix PATH : ${lib.makeBinPath [ clang_12 ] } \
+   --prefix PATH : ${lib.makeBinPath [ clang_11 ] } \
    --suffix PATH : ${lib.makeBinPath [ pkg-config which ]} \
    --suffix CRYSTAL_PATH : lib:$lib/crystal \
    --suffix CRYSTAL_LIBRARY_PATH : ${ lib.makeLibraryPath (buildInputs) } \

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707205916,
-        "narHash": "sha256-fmRJilYGlB7VCt3XsdYxrA0u8e/K84O5xYucerUY0iM=",
+        "lastModified": 1707393347,
+        "narHash": "sha256-xmHgBMyF+Glxs3f8r+AMxJDTNUS01Q5kMjQdgAyw+B8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cc79aa39bbc6eaedaf286ae655b224c71e02907",
+        "rev": "c0b7a892fb042ede583bdaecbbdc804acb85eabe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Using crystal eval fails because it defaults to dynamic linking,
however the libraries needed for dynamic linking aren't present. We
could add those libraries but I decided it would be better to try and
compile a statically linked crystal program instead.